### PR TITLE
Removed href in category and tags a for the time being

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -144,7 +144,7 @@ footer:
   links:
     - label: "Email"
       icon: "fas fa-fw fa-envelope-square"
-      url: "mailto:info@bluegoatlabs.com"
+      url: "mailto:info@bluegoatlabs.com?subject=I want to know more about BGL!&body=I'd like to book a free consultation to discuss my project."
     - label: "Website"
       icon: "fas fa-fw fa-link"
       url: "https://bluegoatlabs.com"

--- a/_includes/category-list.html
+++ b/_includes/category-list.html
@@ -11,8 +11,14 @@
   <p class="page__taxonomy">
     <strong><i class="fas fa-fw fa-folder-open" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].categories_label | default: "Categories:" }} </strong>
     <span itemprop="keywords">
+
+    <!-- href en a
+      {{ category_word | slugify | prepend: path_type | prepend: site.category_archive.path | relative_url }} 
+    -->
     {% for category_word in categories_sorted %}
-      <a href="{{ category_word | slugify | prepend: path_type | prepend: site.category_archive.path | relative_url }}" class="page__taxonomy-item p-category" rel="tag">{{ category_word }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
+      <a href="#"
+      class="page__taxonomy-item p-category" 
+      rel="tag">{{ category_word }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
     {% endfor %}
     </span>
   </p>

--- a/_includes/tag-list.html
+++ b/_includes/tag-list.html
@@ -11,8 +11,15 @@
   <p class="page__taxonomy">
     <strong><i class="fas fa-fw fa-tags" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].tags_label | default: "Tags:" }} </strong>
     <span itemprop="keywords">
+    <!--
+      href in a
+      {{ tag_word | slugify | prepend: path_type | prepend: site.tag_archive.path | relative_url }}
+    -->
     {% for tag_word in tags_sorted %}
-      <a href="{{ tag_word | slugify | prepend: path_type | prepend: site.tag_archive.path | relative_url }}" class="page__taxonomy-item p-category" rel="tag">{{ tag_word }}</a>{% unless forloop.last %}<span class="sep">, </span>{% endunless %}
+      <a href="#" 
+      class="page__taxonomy-item p-category" 
+      rel="tag">{{ tag_word }}</a>
+      {% unless forloop.last %}<span class="sep">, </span>{% endunless %}
     {% endfor %}
     </span>
   </p>


### PR DESCRIPTION
Need to create category archive and tag archive pages to list categories correctly. Right now, the is a config issue so that Jekyll is not creating those pages upon build.